### PR TITLE
Don't ignore .meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,6 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
-*.meta
-
 # Assets (not providing assets through this package)
 */WoWAssets/
 Data/

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 374f52b6aad81af4a91b2665aa80f1d2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AnimationUtility.cs.meta
+++ b/Editor/AnimationUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc992fa4333c77348b2ebb2cf797f5ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AssetConversionManager.cs.meta
+++ b/Editor/AssetConversionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16d9d25d946db63418bdc6b08e4c0f21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ItemCollectionUtility.cs.meta
+++ b/Editor/ItemCollectionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c548253fa36328647990189b2b6bb578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/LiquidUtility.cs.meta
+++ b/Editor/LiquidUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 653c5c1de10bbb544a2bf25d3ee23600
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/M2Utility.cs.meta
+++ b/Editor/M2Utility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b31cf32bfdb666e45a8681c794a21008
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaterialUtility.cs.meta
+++ b/Editor/MaterialUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7885d7dce4f9bfb46968b8067893fc7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/TerrainMaterialGenerator.cs.meta
+++ b/Editor/TerrainMaterialGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e9ae32f6d20954408daeb007feace08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Unity.WowExportUnityifier.Editor.asmdef.meta
+++ b/Editor/Unity.WowExportUnityifier.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89cd92ee786345648b5a914386b17599
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/WMOUtility.cs.meta
+++ b/Editor/WMOUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d40a003d664938478962cc8f370c513
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/WoWExportUnityPostProcessor.cs.meta
+++ b/Editor/WoWExportUnityPostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0d687313cb0a534db288499f6ee8d61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5184f6dd56d983e44a8912b3885efcdc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4606c5a95499d7c44bc7c4f3488ceab6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6091162039c228d4e8c2ef6e30cc70e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts.meta
+++ b/Runtime/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6bcb71826fc249e45be39358d650260d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/BillboardMaterialAdjustment.cs.meta
+++ b/Runtime/Scripts/BillboardMaterialAdjustment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75c31d70e01f0e246ba9e94cc6304c91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders.meta
+++ b/Runtime/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3cf5a905432f104da4a95b850027282
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/PreLegionFunction.hlsl.meta
+++ b/Runtime/Shaders/PreLegionFunction.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0fe3fd4f59a08e448868a16897b0912
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/TerrainChunk.shadergraph.meta
+++ b/Runtime/Shaders/TerrainChunk.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ae1dd2ae891c6d1438890753933477a8
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/Runtime/Shaders/Unlit Billboard.shadergraph.meta
+++ b/Runtime/Shaders/Unlit Billboard.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 79299b5b1eb8b9c4fa79c7669b213170
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/Runtime/Shaders/billboard-transforms.shadersubgraph.meta
+++ b/Runtime/Shaders/billboard-transforms.shadersubgraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 98e622c358bb27e458336510a0674242
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 60072b568d64c40a485e0fc55012dc9f, type: 3}

--- a/Runtime/Shaders/credits.txt.meta
+++ b/Runtime/Shaders/credits.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50e466e844692394ebfeef21b5c1e48c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/wow.unity.asmdef.meta
+++ b/Runtime/wow.unity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 05aac825c9375c34b8272f798f19c01f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a888805939a3d2d438d35b53621599cd
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
They are necessary if you want to use this as a remote package because the package cache folder is immutable, meaning Unity can't regenerate them if they are missing for remote packages, and without them no files are imported.

I'm also adding back all the missing .meta files in this PR.