### PR TITLE
Fix doodad rotation

### DIFF
--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -66,34 +66,34 @@ namespace WowUnity
 
                 Vector3 doodadPosition = Vector3.zero;
                 Quaternion doodadRotation = Quaternion.identity;
-                float doodadScale = float.Parse(fields[8], CultureInfo.InvariantCulture);
+                float doodadScale = float.Parse(fields[8]);
 
                 if (isADT(modelPlacementInformation))
                 {
 
-                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1], CultureInfo.InvariantCulture);
-                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3], CultureInfo.InvariantCulture)) * -1f;
-                    doodadPosition.y = float.Parse(fields[2], CultureInfo.InvariantCulture);
+                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1]);
+                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3])) * -1f;
+                    doodadPosition.y = float.Parse(fields[2]);
 
                     Vector3 eulerRotation = Vector3.zero;
-                    eulerRotation.x = float.Parse(fields[6], CultureInfo.InvariantCulture)) * -1;
-                    eulerRotation.y = float.Parse(fields[5], CultureInfo.InvariantCulture) * -1 - 90;
-                    eulerRotation.z = float.Parse(fields[4], CultureInfo.InvariantCulture)) * -1;
+                    eulerRotation.x = float.Parse(fields[6]) * -1;
+                    eulerRotation.y = float.Parse(fields[5]) * -1 - 90;
+                    eulerRotation.z = float.Parse(fields[4]) * -1;
 
                     doodadRotation.eulerAngles = eulerRotation;
                 }
                 else
                 {
                     doodadPosition = new Vector3(
-                        float.Parse(fields[1], CultureInfo.InvariantCulture), 
-                        float.Parse(fields[3], CultureInfo.InvariantCulture), 
-                        float.Parse(fields[2], CultureInfo.InvariantCulture)
+                        float.Parse(fields[1]), 
+                        float.Parse(fields[3]), 
+                        float.Parse(fields[2])
                     );
                     doodadRotation = new Quaternion(
-                        float.Parse(fields[5], CultureInfo.InvariantCulture) * -1, 
-                        float.Parse(fields[7], CultureInfo.InvariantCulture), 
-                        float.Parse(fields[6], CultureInfo.InvariantCulture) * -1, 
-                        float.Parse(fields[4], CultureInfo.InvariantCulture) * -1
+                        float.Parse(fields[5]) * -1, 
+                        float.Parse(fields[7]), 
+                        float.Parse(fields[6]) * -1, 
+                        float.Parse(fields[4]) * -1
                     );
                 }
 

--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -84,17 +83,8 @@ namespace WowUnity
                 }
                 else
                 {
-                    doodadPosition = new Vector3(
-                        float.Parse(fields[1]), 
-                        float.Parse(fields[3]), 
-                        float.Parse(fields[2])
-                    );
-                    doodadRotation = new Quaternion(
-                        float.Parse(fields[5]) * -1, 
-                        float.Parse(fields[7]), 
-                        float.Parse(fields[6]) * -1, 
-                        float.Parse(fields[4]) * -1
-                    );
+                    doodadPosition = new Vector3(float.Parse(fields[1]), float.Parse(fields[3]), float.Parse(fields[2]));
+                    doodadRotation = new Quaternion(float.Parse(fields[5]) * -1, float.Parse(fields[7]), float.Parse(fields[6]) * -1, float.Parse(fields[4]) * -1);
                 }
 
                 SpawnDoodad(doodadPath, doodadPosition, doodadRotation, doodadScale, instantiatedPrefabGObj.transform);

--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -65,26 +66,35 @@ namespace WowUnity
 
                 Vector3 doodadPosition = Vector3.zero;
                 Quaternion doodadRotation = Quaternion.identity;
-                float doodadScale = float.Parse(fields[8]);
+                float doodadScale = float.Parse(fields[8], CultureInfo.InvariantCulture);
 
                 if (isADT(modelPlacementInformation))
                 {
 
-                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1]);
-                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3])) * -1f;
-                    doodadPosition.y = float.Parse(fields[2]);
+                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1], CultureInfo.InvariantCulture);
+                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3], CultureInfo.InvariantCulture)) * -1f;
+                    doodadPosition.y = float.Parse(fields[2], CultureInfo.InvariantCulture);
 
                     Vector3 eulerRotation = Vector3.zero;
-                    eulerRotation.x = float.Parse(fields[6]);
-                    eulerRotation.y = float.Parse(fields[5]) * -1 - 90;
-                    eulerRotation.z = float.Parse(fields[4]);
+                    eulerRotation.x = float.Parse(fields[6], CultureInfo.InvariantCulture);
+                    eulerRotation.y = float.Parse(fields[5], CultureInfo.InvariantCulture) * -1 - 90;
+                    eulerRotation.z = float.Parse(fields[4], CultureInfo.InvariantCulture);
 
                     doodadRotation.eulerAngles = eulerRotation;
                 }
                 else
                 {
-                    doodadPosition = new Vector3(float.Parse(fields[1]), float.Parse(fields[3]), float.Parse(fields[2]));
-                    doodadRotation = new Quaternion(float.Parse(fields[5]) * -1, float.Parse(fields[7]), float.Parse(fields[6]) * -1, float.Parse(fields[4]) * -1);
+                    doodadPosition = new Vector3(
+                        float.Parse(fields[1], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[3], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[2], CultureInfo.InvariantCulture)
+                    );
+                    doodadRotation = new Quaternion(
+                        float.Parse(fields[5], CultureInfo.InvariantCulture) * -1, 
+                        float.Parse(fields[7], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[6], CultureInfo.InvariantCulture) * -1, 
+                        float.Parse(fields[4], CultureInfo.InvariantCulture) * -1
+                    );
                 }
 
                 SpawnDoodad(doodadPath, doodadPosition, doodadRotation, doodadScale, instantiatedPrefabGObj.transform);

--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -75,9 +75,9 @@ namespace WowUnity
                     doodadPosition.y = float.Parse(fields[2]);
 
                     Vector3 eulerRotation = Vector3.zero;
-                    eulerRotation.x = float.Parse(fields[6]);
+                    eulerRotation.x = float.Parse(fields[6]) * -1;
                     eulerRotation.y = float.Parse(fields[5]) * -1 - 90;
-                    eulerRotation.z = float.Parse(fields[4]);
+                    eulerRotation.z = float.Parse(fields[4]) * -1;
 
                     doodadRotation.eulerAngles = eulerRotation;
                 }

--- a/Editor/WoWExportUnityPostProcessor.cs
+++ b/Editor/WoWExportUnityPostProcessor.cs
@@ -40,6 +40,7 @@ public class WoWExportUnityPostprocessor : AssetPostprocessor
         }
 
         TextureImporter textureImporter = (TextureImporter)assetImporter;
+        textureImporter.textureType = TextureImporterType.Default;
         textureImporter.wrapMode = TextureWrapMode.Clamp;
         textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
         textureImporter.filterMode = FilterMode.Bilinear;

--- a/Editor/WoWExportUnityPostProcessor.cs
+++ b/Editor/WoWExportUnityPostProcessor.cs
@@ -40,7 +40,6 @@ public class WoWExportUnityPostprocessor : AssetPostprocessor
         }
 
         TextureImporter textureImporter = (TextureImporter)assetImporter;
-        textureImporter.textureType = TextureImporterType.Default;
         textureImporter.wrapMode = TextureWrapMode.Clamp;
         textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
         textureImporter.filterMode = FilterMode.Bilinear;


### PR DESCRIPTION
Ref. #4

Every doodad with rotations on x and z were rotated wrong. For me this change fixed all rocks, fences, waterfalls etc. that I tested with.

Edit: I also verified in-game that the bottom picture is the correct one :p 

Before fix:
![Screenshot 2023-06-06 204728](https://github.com/briochie/wow.unity/assets/2248910/64de343c-3f7e-40c0-90e3-3197b128a766)

After fix:
![Screenshot 2023-06-06 204602](https://github.com/briochie/wow.unity/assets/2248910/c151ff3c-0f80-425b-b521-ec5b797dbd07)
