### PR TITLE
POSIX path support

### DIFF
--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -60,9 +60,9 @@ namespace WowUnity
             foreach (string record in records.Skip(1))
             {
                 string[] fields = record.Split(CSV_COLUMN_SEPERATOR);
-                string doodadPath = Path.GetDirectoryName(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(instantiatedPrefabGObj)) + "\\" + fields[0];
+                string doodadPath = Path.GetDirectoryName(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(instantiatedPrefabGObj)) + Path.DirectorySeparatorChar + fields[0];
                 doodadPath = Path.GetFullPath(doodadPath);
-                doodadPath = "Assets\\" + doodadPath.Substring(Application.dataPath.Length + 1); //This is so nifty :3
+                doodadPath = $"Assets{Path.DirectorySeparatorChar}" + doodadPath.Substring(Application.dataPath.Length + 1); //This is so nifty :3
 
                 Vector3 doodadPosition = Vector3.zero;
                 Quaternion doodadRotation = Quaternion.identity;
@@ -135,7 +135,7 @@ namespace WowUnity
             foreach (string path in iteratingList)
             {
                 TextAsset placementData = AssetDatabase.LoadAssetAtPath<TextAsset>(path);
-                string prefabPath = Path.GetDirectoryName(path) + "\\" + Path.GetFileName(path).Replace("_ModelPlacementInformation.csv", ".obj");
+                string prefabPath = Path.GetDirectoryName(path) + Path.DirectorySeparatorChar + Path.GetFileName(path).Replace("_ModelPlacementInformation.csv", ".obj");
                 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
                 GenerateADT(prefab, placementData);
 

--- a/Editor/MaterialUtility.cs
+++ b/Editor/MaterialUtility.cs
@@ -163,7 +163,7 @@ namespace WowUnity
 
         public static void LoadMetadataAndConfigureADT(Material mat, string assetPath)
         {
-            string jsonFilePath = Path.GetDirectoryName(assetPath) + "\\" + mat.name + ".json";
+            string jsonFilePath = Path.GetDirectoryName(assetPath) + Path.DirectorySeparatorChar + mat.name + ".json";
             var sr = new StreamReader(Application.dataPath.Replace("Assets", "") + jsonFilePath);
             var fileContents = sr.ReadToEnd();
             sr.Close();
@@ -177,7 +177,7 @@ namespace WowUnity
                 currentLayer = newChunk.layers[i];
                 string texturePath = Path.Combine(Path.GetDirectoryName(@assetPath), @currentLayer.file);
                 texturePath = Path.GetFullPath(texturePath);
-                texturePath = texturePath.Substring(texturePath.IndexOf("Assets\\"));
+                texturePath = texturePath.Substring(texturePath.IndexOf($"Assets{Path.DirectorySeparatorChar}"));
 
                 Texture2D layerTexture = (Texture2D)AssetDatabase.LoadAssetAtPath(texturePath, typeof(Texture2D));
                 mat.SetTexture("Layer_" + i, layerTexture);


### PR DESCRIPTION
Changed some of the hard coded directory separator to Path.DirectorySeparatorChar, now it partially work on linux also.
![Screenshot_2023-06-10_19-36-20](https://github.com/briochie/wow.unity/assets/74515836/9a985378-4876-491b-9bcb-0ed5b1ff6504)
