### PR TITLE
Add explicit Newtonsoft.Json dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "type": "tool",
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "3.2.1"
+    "com.unity.nuget.newtonsoft-json": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "email": "me@briochie.site",
     "url": "https://github.com/briochie"
   },
-  "type": "tool"
+  "type": "tool",
+  "dependencies": {
+    "com.unity.nuget.newtonsoft-json": "3.2.1"
+  }
 }


### PR DESCRIPTION
We depend on this package, but this dependency isn't explicitly defined so if wow.unity is installed in a project not already containing Newtonsoft.Json then it will throw errors.

Note: I don't know how to add minimum dependencies in the Unity package manager, or if that is even supported. Like there's no specific reason I required version 3.2.1 of this package except for the fact that it was the latest version at the time. If I required 3.0.0 or 1.0.0 or whatever, then Unity would not fetch the latest version automatically.